### PR TITLE
Webhook signature verification tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1125,6 +1125,84 @@ When you exceed the rate limits for an endpoint, you will receive a `429` status
 | `X-RateLimit-Reset` | The amount of time in milliseconds before you can make another request to this endpoint. Pause/sleep your workflow for this duration. |
 | `X-RateLimit-Interval` | The duration of interval in milliseconds for which this rate limit was exceeded. |
 
+## Verify webhooks
+
+ImageKit sends `x-ik-signature` in the webhook request header, which is used to verify the authenticity of the webhook.
+
+Verifing webhook signature is easy with imagekit SDK. All you need is `x-ik-signature`, rawRequestBody and secretKey. You can copy webhook secret from imagekit dashboard.
+
+Here is an example of how to verify the webhook signature in an express.js server.
+
+```js
+const express = require('express');
+const Imagekit = require('imagekit');
+
+// Webhook configs
+const WEBHOOK_ENDPOINT = '/webhook';
+const WEBHOOK_SECRET = 'whsec_0DrqBcZEGejn4fU0P6+EQNTPAEgUnIQW'; // Copy from Imagekit dashboard
+const WEBHOOK_EXPIRY_DURATION = 60 * 1000; // 60 seconds
+
+// Server configs
+const PORT = 8081;
+
+const imagekit = new Imagekit({
+  publicKey: 'pub_...',
+  urlEndpoint: 'https://ik.imagekit.io/example',
+  privateKey: 'pvt_...',
+})
+
+const app = express();
+
+app.post('/webhook', express.raw({ type: 'application/json' }), (req, res) => {
+  // Get `x-ik-signature` from webhook request header & rawRequestBody
+  const signature = req.headers["x-ik-signature"]; // eg. 't=1655788406333,v1=d30758f47fcb31e1fa0109d3b3e2a6c623e699aaf1461cba6bd462ef58ea4b31'
+  const rawBody = req.rawBody;// Unmodified request body encoded as Uint8Array or UTF8 string
+
+  // Verify signature & parse event
+  let webhookResult;
+  try {
+    webhookResult = imagekit.verifyWebhookEvent(rawBody, signature, WEBHOOK_SECRET);
+    // `verifyWebhookEvent` method will throw an error if signature is invalid
+  } catch (e) {
+    // Failed to verify webhook
+    return res.status(401).send(`Webhook error: ${e.message}`);
+  }
+  const { timestamp, event } = webhookResult;
+
+  // Check if webhook has expired
+  if (timestamp + WEBHOOK_EXPIRY_DURATION < Date.now()) {
+    return res.status(401).send('Webhook signature expired');
+  }
+
+  // Handle webhook
+  switch (event.type) {
+    case 'video.transformation.accepted':
+      // It is triggered when a new video transformation request is accepted for processing. You can use this for debugging purposes.
+      break;
+    case 'video.transformation.ready':
+      // It is triggered when a video encoding is finished and the transformed resource is ready to be served. You should listen to this webhook and update any flag in your database or CMS against that particular asset so your application can start showing it to users.
+      break;
+    case 'video.transformation.error':
+      // It is triggered if an error occurs during encoding. Listen to this webhook to log the reason. You should check your origin and URL-endpoint settings if the reason is related to download failure. If the reason seems like an error on the ImageKit side, then raise a support ticket at support@imagekit.io.
+      break;
+    // ... handle other event types
+    default:
+      console.log(`Unhandled event type ${event.type}`);
+  }
+
+  // Acknowledge webhook is received and processed successfully
+  res.status(200).end();
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+  console.log(
+    `Webhook endpoint: 'http://localhost:${PORT}${WEBHOOK_ENDPOINT}'`,
+    'Do replace 'localhost' with public endpoint'
+  );
+});
+```
+
 ## Support
 
 For any feedback or to report any issues or general implementation support, please reach out to [support@imagekit.io](mailto:support@imagekit.io)

--- a/README.md
+++ b/README.md
@@ -1127,7 +1127,7 @@ When you exceed the rate limits for an endpoint, you will receive a `429` status
 
 ## Verify webhook events
 
-ImageKit sends `x-ik-signature` in the webhook request header, which is used to verify the authenticity of the webhook.
+ImageKit sends `x-ik-signature` in the webhook request header, which can be used to verify the authenticity of the webhook request.
 
 Verifing webhook signature is easy with imagekit SDK. All you need is `x-ik-signature`, rawRequestBody and secretKey. You can copy webhook secret from imagekit dashboard.
 
@@ -1136,15 +1136,15 @@ const {
     timestamp,  // Unix timestamp in milliseconds
     event,      // Parsed webhook event object
 } = imagekit.verifyWebhookEvent(
-    `{"type":"video.transformation.accepted","id":"58e6d24d-6098-4319-be8d-40c3cb0a402d"...`, // Raw request body encoded as Uint8Array or UTF8 string
-    't=1655788406333,v1=d30758f47fcb31e1fa0109d3b3e2a6c623e699aaf1461cba6bd462ef58ea4b31' // Webhook secret key
+    '{"type":"video.transformation.accepted","id":"58e6d24d-6098-4319-be8d-40c3cb0a402d"...', // Raw request body encoded as Uint8Array or UTF8 string
+    't=1655788406333,v1=d30758f47fcb31e1fa0109d3b3e2a6c623e699aaf1461cba6bd462ef58ea4b31', // Webhook secret key
     'whsec_...' // Webhook secret key
 ) // Throws an error if signature is invalid
 
 // { timestamp: 1655788406333, event: {"type":"video.transformation.accepted","id":"58e6d24d-6098-4319-be8d-40c3cb0a402d"...} }
 ```
 
-Here is an example of implementing with express.js server.
+Here is an example for implementing with express.js server.
 
 ```js
 const express = require('express');

--- a/README.md
+++ b/README.md
@@ -1125,13 +1125,26 @@ When you exceed the rate limits for an endpoint, you will receive a `429` status
 | `X-RateLimit-Reset` | The amount of time in milliseconds before you can make another request to this endpoint. Pause/sleep your workflow for this duration. |
 | `X-RateLimit-Interval` | The duration of interval in milliseconds for which this rate limit was exceeded. |
 
-## Verify webhooks
+## Verify webhook events
 
 ImageKit sends `x-ik-signature` in the webhook request header, which is used to verify the authenticity of the webhook.
 
 Verifing webhook signature is easy with imagekit SDK. All you need is `x-ik-signature`, rawRequestBody and secretKey. You can copy webhook secret from imagekit dashboard.
 
-Here is an example of how to verify the webhook signature in an express.js server.
+```js
+const {
+    timestamp,  // Unix timestamp in milliseconds
+    event,      // Parsed webhook event object
+} = imagekit.verifyWebhookEvent(
+    `{"type":"video.transformation.accepted","id":"58e6d24d-6098-4319-be8d-40c3cb0a402d"...`, // Raw request body encoded as Uint8Array or UTF8 string
+    't=1655788406333,v1=d30758f47fcb31e1fa0109d3b3e2a6c623e699aaf1461cba6bd462ef58ea4b31' // Webhook secret key
+    'whsec_...' // Webhook secret key
+) // Throws an error if signature is invalid
+
+// { timestamp: 1655788406333, event: {"type":"video.transformation.accepted","id":"58e6d24d-6098-4319-be8d-40c3cb0a402d"...} }
+```
+
+Here is an example of implementing with express.js server.
 
 ```js
 const express = require('express');
@@ -1139,7 +1152,7 @@ const Imagekit = require('imagekit');
 
 // Webhook configs
 const WEBHOOK_ENDPOINT = '/webhook';
-const WEBHOOK_SECRET = 'whsec_0DrqBcZEGejn4fU0P6+EQNTPAEgUnIQW'; // Copy from Imagekit dashboard
+const WEBHOOK_SECRET = 'whsec_...'; // Copy from Imagekit dashboard
 const WEBHOOK_EXPIRY_DURATION = 60 * 1000; // 60 seconds
 
 // Server configs

--- a/README.md
+++ b/README.md
@@ -1132,16 +1132,24 @@ ImageKit sends `x-ik-signature` in the webhook request header, which can be used
 Verifing webhook signature is easy with imagekit SDK. All you need is `x-ik-signature`, rawRequestBody and secretKey. You can copy webhook secret from imagekit dashboard.
 
 ```js
-const {
-    timestamp,  // Unix timestamp in milliseconds
-    event,      // Parsed webhook event object
-} = imagekit.verifyWebhookEvent(
-    '{"type":"video.transformation.accepted","id":"58e6d24d-6098-4319-be8d-40c3cb0a402d"...', // Raw request body encoded as Uint8Array or UTF8 string
-    't=1655788406333,v1=d30758f47fcb31e1fa0109d3b3e2a6c623e699aaf1461cba6bd462ef58ea4b31', // Webhook secret key
-    'whsec_...' // Webhook secret key
-) // Throws an error if signature is invalid
-
-// { timestamp: 1655788406333, event: {"type":"video.transformation.accepted","id":"58e6d24d-6098-4319-be8d-40c3cb0a402d"...} }
+try {
+    const {
+        timestamp,  // Unix timestamp in milliseconds
+        event,      // Parsed webhook event object
+    } = imagekit.verifyWebhookEvent(
+        '{"type":"video.transformation.accepted","id":"58e6d24d-6098-4319-be8d-40c3cb0a402d"...', // Raw request body encoded as Uint8Array or UTF8 string
+        't=1655788406333,v1=d30758f47fcb31e1fa0109d3b3e2a6c623e699aaf1461cba6bd462ef58ea4b31', // Request header `x-ik-signature`
+        'whsec_...' // Webhook secret
+    )
+    // { timestamp: 1655788406333, event: {"type":"video.transformation.accepted","id":"58e6d24d-6098-4319-be8d-40c3cb0a402d"...} }
+} catch (err) {
+    // `verifyWebhookEvent` will throw an error if the signature is invalid
+    // And the webhook event must be ignored and not processed
+    console.log(err);
+    // Under normal circumstances you may catch following errors:
+    // - `Error: Incorrect signature` - you may check the webhook secret & the request body being used.
+    // - `Error: Signature missing` or `Error: Timestamp missing` or `Error: Invalid timestamp` - you may check `x-ik-signature` header used.
+}
 ```
 
 Here is an example for implementing with express.js server.

--- a/index.ts
+++ b/index.ts
@@ -40,7 +40,7 @@ import { IKCallback } from "./libs/interfaces/IKCallback";
 import manage from "./libs/manage";
 import signature from "./libs/signature";
 import upload from "./libs/upload";
-import { verify as verifyWebhookSignature } from "./utils/webhook-signature";
+import { verify as verifyWebhookEvent } from "./utils/webhook-signature";
 import customMetadataField from "./libs/manage/custom-metadata-field";
 /*
     Implementations
@@ -76,16 +76,7 @@ const promisify = function <T = void>(thisContext: ImageKit, fn: Function) {
     }
   };
 };
-
-const Webhook = {
-  verify: verifyWebhookSignature,
-}
-
-class ImageKitStaticUtils {
-  static Webhook = Webhook;
-}
-
-class ImageKit extends ImageKitStaticUtils {
+class ImageKit {
   options: ImageKitOptions = {
     uploadEndpoint: "https://upload.imagekit.io/api/v1/files/upload",
     publicKey: "",
@@ -95,7 +86,6 @@ class ImageKit extends ImageKitStaticUtils {
   };
 
   constructor(opts: ImageKitOptions = {} as ImageKitOptions) {
-    super()
     this.options = _.extend(this.options, opts);
     if (!this.options.publicKey) {
       throw new Error(errorMessages.MANDATORY_PUBLIC_KEY_MISSING.message);
@@ -677,6 +667,14 @@ class ImageKit extends ImageKitStaticUtils {
   pHashDistance(firstPHash: string, secondPHash: string): number | Error {
     return pHashUtils.pHashDistance(firstPHash, secondPHash);
   }
+
+  /**
+   * @param payload - Raw webhook request body (Encoded as UTF8 string or Buffer)
+   * @param signature - Webhook signature as UTF8 encoded strings (Stored in `x-ik-signature` header of the request)
+   * @param secret - Webhook secret as UTF8 encoded string [Copy from ImageKit dashboard](https://imagekit.io/dashboard/developer/webhooks)
+   * @returns \{ `timstamp`: Verified UNIX epoch timestamp if signature, `event`: Parsed webhook event payload \}
+   */
+  verifyWebhookEvent = verifyWebhookEvent;
 }
 
 export = ImageKit;

--- a/index.ts
+++ b/index.ts
@@ -77,7 +77,7 @@ const promisify = function <T = void>(thisContext: ImageKit, fn: Function) {
   };
 };
 
-export const Webhook = {
+const Webhook = {
   verify: verifyWebhookSignature,
 }
 

--- a/index.ts
+++ b/index.ts
@@ -40,6 +40,7 @@ import { IKCallback } from "./libs/interfaces/IKCallback";
 import manage from "./libs/manage";
 import signature from "./libs/signature";
 import upload from "./libs/upload";
+import { verify as verifyWebhookSignature } from "./utils/webhook-signature";
 import customMetadataField from "./libs/manage/custom-metadata-field";
 /*
     Implementations
@@ -76,7 +77,15 @@ const promisify = function <T = void>(thisContext: ImageKit, fn: Function) {
   };
 };
 
-class ImageKit {
+export const Webhook = {
+  verify: verifyWebhookSignature,
+}
+
+class ImageKitStaticUtils {
+  static Webhook = Webhook;
+}
+
+class ImageKit extends ImageKitStaticUtils {
   options: ImageKitOptions = {
     uploadEndpoint: "https://upload.imagekit.io/api/v1/files/upload",
     publicKey: "",
@@ -86,6 +95,7 @@ class ImageKit {
   };
 
   constructor(opts: ImageKitOptions = {} as ImageKitOptions) {
+    super()
     this.options = _.extend(this.options, opts);
     if (!this.options.publicKey) {
       throw new Error(errorMessages.MANDATORY_PUBLIC_KEY_MISSING.message);

--- a/libs/constants/errorMessages.ts
+++ b/libs/constants/errorMessages.ts
@@ -42,4 +42,9 @@ export default {
     "INVALID_FILE_PATH": { message: "Invalid value for filePath", help: "Pass the full path of the file. For example - /path/to/file.jpg" },
     "INVALID_NEW_FILE_NAME": { message: "Invalid value for newFileName. It should be a string.", help: "" },
     "INVALID_PURGE_CACHE": { message: "Invalid value for purgeCache. It should be boolean.", help: "" },
+    // Webhook signature
+    "VERIFY_WEBHOOK_EVENT_SIGNATURE_INCORRECT": { message: "Incorrect signature", help: "Please pass x-ik-signature header as utf8 string" },
+    "VERIFY_WEBHOOK_EVENT_SIGNATURE_MISSING": { message: "Signature missing", help: "Please pass x-ik-signature header as utf8 string" },
+    "VERIFY_WEBHOOK_EVENT_TIMESTAMP_MISSING": { message: "Timestamp missing", help: "Please pass x-ik-signature header as utf8 string" },
+    "VERIFY_WEBHOOK_EVENT_TIMESTAMP_INVALID": { message: "Timestamp invalid", help: "Please pass x-ik-signature header as utf8 string" },
 };

--- a/libs/interfaces/index.ts
+++ b/libs/interfaces/index.ts
@@ -20,7 +20,7 @@ import { RenameFileOptions, RenameFileResponse } from "./Rename"
 import {
   WebhookEvent,
   WebhookEventVideoAccepted,
-  WebhookEventVideoCompleted,
+  WebhookEventVideoReady,
   WebhookEventVideoFailed,
 } from "./webhookEvent";
 
@@ -64,7 +64,7 @@ export type {
   RenameFileResponse,
   WebhookEvent,
   WebhookEventVideoAccepted,
-  WebhookEventVideoCompleted,
+  WebhookEventVideoReady,
   WebhookEventVideoFailed,
 };
 export type { IKCallback } from "./IKCallback";

--- a/libs/interfaces/index.ts
+++ b/libs/interfaces/index.ts
@@ -21,7 +21,7 @@ import {
   WebhookEvent,
   WebhookEventVideoAccepted,
   WebhookEventVideoReady,
-  WebhookEventVideoFailed,
+  WebhookEventVideoError,
 } from "./webhookEvent";
 
 type FinalUrlOptions = ImageKitOptions & UrlOptions; // actual options used to construct url
@@ -65,6 +65,6 @@ export type {
   WebhookEvent,
   WebhookEventVideoAccepted,
   WebhookEventVideoReady,
-  WebhookEventVideoFailed,
+  WebhookEventVideoError,
 };
 export type { IKCallback } from "./IKCallback";

--- a/libs/interfaces/index.ts
+++ b/libs/interfaces/index.ts
@@ -17,6 +17,12 @@ import { MoveFolderOptions, MoveFolderResponse, MoveFolderError } from "./MoveFo
 import { DeleteFileVersionOptions, RestoreFileVersionOptions } from "./FileVersion"
 import { CreateCustomMetadataFieldOptions, CustomMetadataField, UpdateCustomMetadataFieldOptions, GetCustomMetadataFieldsOptions } from "./CustomMetatadaField"
 import { RenameFileOptions, RenameFileResponse } from "./Rename"
+import {
+  WebhookEvent,
+  WebhookEventVideoAccepted,
+  WebhookEventVideoCompleted,
+  WebhookEventVideoFailed,
+} from "./webhookEvent";
 
 type FinalUrlOptions = ImageKitOptions & UrlOptions; // actual options used to construct url
 
@@ -56,5 +62,9 @@ export type {
   UpdateCustomMetadataFieldOptions,
   RenameFileOptions,
   RenameFileResponse,
+  WebhookEvent,
+  WebhookEventVideoAccepted,
+  WebhookEventVideoCompleted,
+  WebhookEventVideoFailed,
 };
 export type { IKCallback } from "./IKCallback";

--- a/libs/interfaces/index.ts
+++ b/libs/interfaces/index.ts
@@ -19,9 +19,9 @@ import { CreateCustomMetadataFieldOptions, CustomMetadataField, UpdateCustomMeta
 import { RenameFileOptions, RenameFileResponse } from "./Rename"
 import {
   WebhookEvent,
-  WebhookEventVideoAccepted,
-  WebhookEventVideoReady,
-  WebhookEventVideoError,
+  WebhookEventVideoTransformationAccepted,
+  WebhookEventVideoTransformationReady,
+  WebhookEventVideoTransformationError,
 } from "./webhookEvent";
 
 type FinalUrlOptions = ImageKitOptions & UrlOptions; // actual options used to construct url
@@ -63,8 +63,8 @@ export type {
   RenameFileOptions,
   RenameFileResponse,
   WebhookEvent,
-  WebhookEventVideoAccepted,
-  WebhookEventVideoReady,
-  WebhookEventVideoError,
+  WebhookEventVideoTransformationAccepted,
+  WebhookEventVideoTransformationReady,
+  WebhookEventVideoTransformationError,
 };
 export type { IKCallback } from "./IKCallback";

--- a/libs/interfaces/webhookEvent.ts
+++ b/libs/interfaces/webhookEvent.ts
@@ -60,8 +60,8 @@ export interface WebhookEventVideoReady extends WebhookEventVideoBase {
   };
 }
 
-export interface WebhookEventVideoFailed extends WebhookEventVideoBase {
-  type: "video.transformation.failed";
+export interface WebhookEventVideoError extends WebhookEventVideoBase {
+  type: "video.transformation.error";
   data: {
     asset: Asset;
     transformation: {
@@ -77,4 +77,4 @@ export interface WebhookEventVideoFailed extends WebhookEventVideoBase {
 export type WebhookEvent =
   | WebhookEventVideoAccepted
   | WebhookEventVideoReady
-  | WebhookEventVideoFailed;
+  | WebhookEventVideoError;

--- a/libs/interfaces/webhookEvent.ts
+++ b/libs/interfaces/webhookEvent.ts
@@ -36,8 +36,8 @@ export interface WebhookEventVideoAccepted extends WebhookEventVideoBase {
   };
 }
 
-export interface WebhookEventVideoCompleted extends WebhookEventVideoBase {
-  type: "video.transformation.completed";
+export interface WebhookEventVideoReady extends WebhookEventVideoBase {
+  type: "video.transformation.ready";
   timings: {
     donwload_duration: number;
     encoding_duration: number;
@@ -76,5 +76,5 @@ export interface WebhookEventVideoFailed extends WebhookEventVideoBase {
 
 export type WebhookEvent =
   | WebhookEventVideoAccepted
-  | WebhookEventVideoCompleted
+  | WebhookEventVideoReady
   | WebhookEventVideoFailed;

--- a/libs/interfaces/webhookEvent.ts
+++ b/libs/interfaces/webhookEvent.ts
@@ -1,0 +1,80 @@
+type Asset = {
+  url: string;
+};
+
+type TransformationOptions = {
+  video_codec: string;
+  audio_codec: string;
+  auto_rotate: boolean;
+  quality: number;
+  format: string;
+};
+
+interface WebhookEventBase {
+  type: string;
+  id: string;
+  created_at: string; // Date
+}
+
+/** WebhookEvent for "video.transformation.*" type */
+interface WebhookEventVideoBase extends WebhookEventBase {
+  request: {
+    x_request_id: string;
+    url: string;
+    user_agent: string;
+  };
+}
+
+export interface WebhookEventVideoAccepted extends WebhookEventVideoBase {
+  type: "video.transformation.accepted";
+  data: {
+    asset: Asset;
+    transformation: {
+      type: string;
+      options: TransformationOptions;
+    };
+  };
+}
+
+export interface WebhookEventVideoCompleted extends WebhookEventVideoBase {
+  type: "video.transformation.completed";
+  timings: {
+    donwload_duration: number;
+    encoding_duration: number;
+  };
+  data: {
+    asset: Asset;
+    transformation: {
+      type: string;
+      options: TransformationOptions;
+      output: {
+        url: string;
+        video_metadata: {
+          duration: number;
+          width: number;
+          height: number;
+          bitrate: number;
+        };
+      };
+    };
+  };
+}
+
+export interface WebhookEventVideoFailed extends WebhookEventVideoBase {
+  type: "video.transformation.failed";
+  data: {
+    asset: Asset;
+    transformation: {
+      type: string;
+      options: TransformationOptions;
+      error: {
+        reason: string;
+      };
+    };
+  };
+}
+
+export type WebhookEvent =
+  | WebhookEventVideoAccepted
+  | WebhookEventVideoCompleted
+  | WebhookEventVideoFailed;

--- a/libs/interfaces/webhookEvent.ts
+++ b/libs/interfaces/webhookEvent.ts
@@ -17,7 +17,7 @@ interface WebhookEventBase {
 }
 
 /** WebhookEvent for "video.transformation.*" type */
-interface WebhookEventVideoBase extends WebhookEventBase {
+interface WebhookEventVideoTransformationBase extends WebhookEventBase {
   request: {
     x_request_id: string;
     url: string;
@@ -25,7 +25,7 @@ interface WebhookEventVideoBase extends WebhookEventBase {
   };
 }
 
-export interface WebhookEventVideoAccepted extends WebhookEventVideoBase {
+export interface WebhookEventVideoTransformationAccepted extends WebhookEventVideoTransformationBase {
   type: "video.transformation.accepted";
   data: {
     asset: Asset;
@@ -36,7 +36,7 @@ export interface WebhookEventVideoAccepted extends WebhookEventVideoBase {
   };
 }
 
-export interface WebhookEventVideoReady extends WebhookEventVideoBase {
+export interface WebhookEventVideoTransformationReady extends WebhookEventVideoTransformationBase {
   type: "video.transformation.ready";
   timings: {
     donwload_duration: number;
@@ -60,7 +60,7 @@ export interface WebhookEventVideoReady extends WebhookEventVideoBase {
   };
 }
 
-export interface WebhookEventVideoError extends WebhookEventVideoBase {
+export interface WebhookEventVideoTransformationError extends WebhookEventVideoTransformationBase {
   type: "video.transformation.error";
   data: {
     asset: Asset;
@@ -75,6 +75,6 @@ export interface WebhookEventVideoError extends WebhookEventVideoBase {
 }
 
 export type WebhookEvent =
-  | WebhookEventVideoAccepted
-  | WebhookEventVideoReady
-  | WebhookEventVideoError;
+  | WebhookEventVideoTransformationAccepted
+  | WebhookEventVideoTransformationReady
+  | WebhookEventVideoTransformationError;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagekit",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Offical NodeJS SDK for ImageKit.io integration",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagekit",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Offical NodeJS SDK for ImageKit.io integration",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/tests/webhook-signature.js
+++ b/tests/webhook-signature.js
@@ -1,4 +1,4 @@
-import { Webhook } from "../index";
+import ImageKit from "../index";
 import { expect } from "chai";
 
 // Sample webhook data
@@ -17,7 +17,7 @@ const WEBHOOK_REQUEST_SAMPLE = Object.seal({
 });
 
 describe("WebhookSignature", function () {
-  const { verify } = Webhook;
+  const verify = (new ImageKit(require("./data").initializationParams)).verifyWebhookEvent;
 
   context("Test Webhook.verify() - Positive cases", () => {
     it("Verify with body as string", () => {

--- a/tests/webhook-signature.js
+++ b/tests/webhook-signature.js
@@ -1,0 +1,145 @@
+import { Webhook } from "../index";
+import { expect } from "chai";
+
+// Sample webhook data
+const WEBHOOK_REQUEST_SAMPLE_SECRET = "whsec_xeO2UNkfKMQnfJf7Q/Qx+fYptL1wabXd";
+const WEBHOOK_REQUEST_SAMPLE_TIMESTAMP = new Date(1655788406333);
+const WEBHOOK_REQUEST_SAMPLE_SIGNATURE_HEADER =
+  "t=1655788406333,v1=d30758f47fcb31e1fa0109d3b3e2a6c623e699aaf1461cba6bd462ef58ea4b31";
+const WEBHOOK_REQUEST_SAMPLE_RAW_BODY =
+  '{"type":"video.transformation.accepted","id":"58e6d24d-6098-4319-be8d-40c3cb0a402d","created_at":"2022-06-20T11:59:58.461Z","request":{"x_request_id":"fa98fa2e-d6cd-45b4-acf5-bc1d2bbb8ba9","url":"http://ik.imagekit.io/demo/sample-video.mp4?tr=f-webm,q-10","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:101.0) Gecko/20100101 Firefox/101.0"},"data":{"asset":{"url":"http://ik.imagekit.io/demo/sample-video.mp4"},"transformation":{"type":"video-transformation","options":{"video_codec":"vp9","audio_codec":"opus","auto_rotate":true,"quality":10,"format":"webm"}}}}';
+const WEBHOOK_REQUEST_SAMPLE = Object.seal({
+  secret: WEBHOOK_REQUEST_SAMPLE_SECRET,
+  timestamp: WEBHOOK_REQUEST_SAMPLE_TIMESTAMP,
+  signatureHeader: WEBHOOK_REQUEST_SAMPLE_SIGNATURE_HEADER,
+  rawBody: WEBHOOK_REQUEST_SAMPLE_RAW_BODY,
+  body: JSON.parse(WEBHOOK_REQUEST_SAMPLE_RAW_BODY),
+});
+
+describe("WebhookSignature", function () {
+  const { verify } = Webhook;
+
+  context("Test Webhook.verify() - Positive cases", () => {
+    it("Verify with body as string", () => {
+      const webhookRequest = WEBHOOK_REQUEST_SAMPLE;
+      const { timestamp, event } = verify(
+        webhookRequest.rawBody,
+        webhookRequest.signatureHeader,
+        webhookRequest.secret
+      );
+      expect(timestamp).to.equal(webhookRequest.timestamp.getTime());
+      expect(event).to.deep.equal(webhookRequest.body);
+    });
+    it("Verify with body as Buffer", () => {
+      const webhookRequest = WEBHOOK_REQUEST_SAMPLE;
+      const { timestamp, event } = verify(
+        Buffer.from(webhookRequest.rawBody),
+        webhookRequest.signatureHeader,
+        webhookRequest.secret
+      );
+      expect(timestamp).to.equal(webhookRequest.timestamp.getTime());
+      expect(event).to.deep.equal(webhookRequest.body);
+    });
+    it("Verify with body as Uint8Array", () => {
+      const webhookRequest = WEBHOOK_REQUEST_SAMPLE;
+      const rawBody = Uint8Array.from(Buffer.from(webhookRequest.rawBody));
+      const { timestamp, event } = verify(
+        rawBody,
+        webhookRequest.signatureHeader,
+        webhookRequest.secret
+      );
+      expect(timestamp).to.equal(webhookRequest.timestamp.getTime());
+      expect(event).to.deep.equal(webhookRequest.body);
+    });
+  });
+
+  context("Test WebhookSignature.verify() - Negative cases", () => {
+    it("Timestamp missing", () => {
+      const webhookRequest = WEBHOOK_REQUEST_SAMPLE;
+      const invalidSignature =
+        "v1=b6bc2aa82491c32f1cbef0eb52b7ffffff467ea65a03b5d4ccdcfb9e0941c946";
+      try {
+        verify(webhookRequest.rawBody, invalidSignature, webhookRequest.secret);
+        expect.fail("Expected exception");
+      } catch (e) {
+        expect(e.message).to.equal("Timestamp missing");
+      }
+    });
+    it("Timestamp invalid", () => {
+      const webhookRequest = WEBHOOK_REQUEST_SAMPLE;
+      const invalidSignature =
+        "t=notANumber,v1=b6bc2aa82491c32f1cbef0eb52b7ffffff467ea65a03b5d4ccdcfb9e0941c946";
+      try {
+        verify(webhookRequest.rawBody, invalidSignature, webhookRequest.secret);
+        expect.fail("Expected exception");
+      } catch (e) {
+        expect(e.message).to.equal("Timestamp invalid");
+      }
+    });
+    it("Signature missing", () => {
+      const webhookRequest = WEBHOOK_REQUEST_SAMPLE;
+      const invalidSignature = "t=1656326161409";
+      try {
+        verify(webhookRequest.rawBody, invalidSignature, webhookRequest.secret);
+        expect.fail("Expected exception");
+      } catch (e) {
+        expect(e.message).to.equal("Signature missing");
+      }
+    });
+    it("Incorrect signature - v1 manipulated", () => {
+      const webhookRequest = WEBHOOK_REQUEST_SAMPLE;
+      const invalidSignature = `t=${webhookRequest.timestamp.getTime()},v1=d66b01d8f1e158d1af7646184716037510ac8ce0a1e70b726a1b698f954785b2`;
+      try {
+        verify(webhookRequest.rawBody, invalidSignature, webhookRequest.secret);
+        expect.fail("Expected exception");
+      } catch (e) {
+        expect(e.message).to.equal("Incorrect signature");
+      }
+    });
+    it("Incorrect signature - incorrect request body", () => {
+      const webhookRequest = WEBHOOK_REQUEST_SAMPLE;
+      const incorrectBody = { hello: "world" };
+      const incorrectRawBody = JSON.stringify(incorrectBody);
+      try {
+        verify(
+          incorrectRawBody,
+          webhookRequest.signatureHeader,
+          webhookRequest.secret
+        );
+        expect.fail("Expected exception");
+      } catch (e) {
+        expect(e.message).to.equal("Incorrect signature");
+      }
+    });
+    it("Incorrect signature - timestamp manipulated", () => {
+      const webhookRequest = WEBHOOK_REQUEST_SAMPLE;
+      const incorrectSignature = webhookRequest.signatureHeader.replace(
+        `t=${webhookRequest.timestamp.getTime()}`,
+        `t=${webhookRequest.timestamp.getTime() + 1}`
+      ); // Correct timestamp replaced with incorrect timestamp
+      try {
+        verify(
+          webhookRequest.rawBody,
+          incorrectSignature,
+          webhookRequest.secret
+        );
+        expect.fail("Expected exception");
+      } catch (e) {
+        expect(e.message).to.equal("Incorrect signature");
+      }
+    });
+    it("Incorrect signature - different secret", () => {
+      const webhookRequest = WEBHOOK_REQUEST_SAMPLE;
+      try {
+        verify(
+          webhookRequest.rawBody,
+          webhookRequest.signatureHeader,
+          "A different secret"
+        );
+        expect.fail("Expected exception");
+      } catch (e) {
+        expect(e.message).to.equal("Incorrect signature");
+      }
+    });
+  });
+});

--- a/utils/webhook-signature.ts
+++ b/utils/webhook-signature.ts
@@ -1,0 +1,101 @@
+import { createHmac } from "crypto";
+import { isNaN } from "lodash";
+import type { WebhookEvent } from "../libs/interfaces";
+
+class WebhookSignatureError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WebhookSignatureError";
+  }
+}
+
+/**
+ * @description Enum for Webhook signature item names
+ */
+enum SignatureItems {
+  Timestamp = "t",
+  V1 = "v1",
+}
+
+const HASH_ALGORITHM = "sha256";
+
+/**
+ * @param timstamp - Webhook request timestamp
+ * @param payload - Webhook payload as UTF8 encoded string
+ * @param secret - Webhook secret as UTF8 encoded string
+ * @returns Hmac with webhook secret as key and `${timestamp}.${payload}` as hash payload.
+ */
+const computeHmac = (
+  timstamp: Date,
+  payload: string,
+  secret: string
+): string => {
+  const hashPayload = `${timstamp.getTime()}.${payload}`;
+  return createHmac(HASH_ALGORITHM, secret).update(hashPayload).digest("hex");
+};
+
+/**
+ * @description Extract items from webhook signature string
+ */
+const deserializeSignature = (
+  signature: string
+): {
+  timestamp: number;
+  v1: string;
+} => {
+  const items = signature.split(",");
+  const itemMap = items.map((item) => item.split("=")); // eg. [["t", 1656921250765], ["v1", 'afafafafafaf']]
+  const timestampString = itemMap.find(
+    ([key]) => key === SignatureItems.Timestamp
+  )?.[1]; // eg. 1656921250765
+
+  // parse timestamp
+  if (timestampString === undefined) {
+    throw new WebhookSignatureError("Timestamp missing");
+  }
+  const timestamp = parseInt(timestampString, 10);
+  if (isNaN(timestamp) || timestamp < 0) {
+    throw new WebhookSignatureError("Timestamp invalid");
+  }
+
+  // parse v1 signature
+  const v1 = itemMap.find(([key]) => key === SignatureItems.V1)?.[1]; // eg. 'afafafafafaf'
+  if (v1 === undefined) {
+    throw new WebhookSignatureError("Signature missing");
+  }
+
+  return { timestamp, v1 };
+};
+
+/**
+ * @param payload - Webhook request (Raw body)
+ * @param signature - Webhook signature as UTF8 encoded strings (Stored in `x-ik-signature` header of the request)
+ * @param secret - Webhook secret as UTF8 encoded string [Copy from ImageKit dashboard](https://imagekit.io/dashboard/developer/webhooks)
+ * @returns \{ `timstamp`: Verified UNIX epoch timestamp if signature, `event`: Parsed webhook event payload \}
+ */
+export const verify = (
+  payload: string | Uint8Array,
+  signature: string,
+  secret: string
+): {
+  timestamp: number;
+  event: WebhookEvent;
+} => {
+  const { timestamp, v1 } = deserializeSignature(signature);
+  const payloadAsString: string =
+    typeof payload === "string"
+      ? payload
+      : Buffer.from(payload).toString("utf8");
+  const computedHmac = computeHmac(
+    new Date(timestamp),
+    payloadAsString,
+    secret
+  );
+  if (v1 !== computedHmac) {
+    throw new WebhookSignatureError("Incorrect signature");
+  }
+  return {
+    timestamp,
+    event: JSON.parse(payloadAsString) as WebhookEvent,
+  };
+};

--- a/utils/webhook-signature.ts
+++ b/utils/webhook-signature.ts
@@ -1,13 +1,7 @@
 import { createHmac } from "crypto";
 import { isNaN } from "lodash";
+import errorMessages from "../libs/constants/errorMessages";
 import type { WebhookEvent } from "../libs/interfaces";
-
-class WebhookSignatureError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "WebhookSignatureError";
-  }
-}
 
 /**
  * @description Enum for Webhook signature item names
@@ -51,17 +45,23 @@ const deserializeSignature = (
 
   // parse timestamp
   if (timestampString === undefined) {
-    throw new WebhookSignatureError("Timestamp missing");
+    throw new Error(
+      errorMessages.VERIFY_WEBHOOK_EVENT_TIMESTAMP_MISSING.message
+    );
   }
   const timestamp = parseInt(timestampString, 10);
   if (isNaN(timestamp) || timestamp < 0) {
-    throw new WebhookSignatureError("Timestamp invalid");
+    throw new Error(
+      errorMessages.VERIFY_WEBHOOK_EVENT_TIMESTAMP_INVALID.message
+    );
   }
 
   // parse v1 signature
   const v1 = itemMap.find(([key]) => key === SignatureItems.V1)?.[1]; // eg. 'afafafafafaf'
   if (v1 === undefined) {
-    throw new WebhookSignatureError("Signature missing");
+    throw new Error(
+      errorMessages.VERIFY_WEBHOOK_EVENT_SIGNATURE_MISSING.message
+    );
   }
 
   return { timestamp, v1 };
@@ -92,7 +92,9 @@ export const verify = (
     secret
   );
   if (v1 !== computedHmac) {
-    throw new WebhookSignatureError("Incorrect signature");
+    throw new Error(
+      errorMessages.VERIFY_WEBHOOK_EVENT_SIGNATURE_INCORRECT.message
+    );
   }
   return {
     timestamp,

--- a/utils/webhook-signature.ts
+++ b/utils/webhook-signature.ts
@@ -68,7 +68,7 @@ const deserializeSignature = (
 };
 
 /**
- * @param payload - Webhook request (Raw body)
+ * @param payload - Raw webhook request body (Encoded as UTF8 string or Buffer)
  * @param signature - Webhook signature as UTF8 encoded strings (Stored in `x-ik-signature` header of the request)
  * @param secret - Webhook secret as UTF8 encoded string [Copy from ImageKit dashboard](https://imagekit.io/dashboard/developer/webhooks)
  * @returns \{ `timstamp`: Verified UNIX epoch timestamp if signature, `event`: Parsed webhook event payload \}


### PR DESCRIPTION
### Package version bumped: imagekit@4.0.1 -> imagekit@4.1.0

### New Feature

Imagekit.verifyWebhookEvent()

### Usage of `Imagekit.verifyWebhookEvent`

In JavaScript

```js
const Imagekit = require("imagekit");
// Or for ESM
import Imagekit from "imagekit";

const WEBHOOK_SECRET = "whsec_...";

const imagekit = new Imagekit({
    publicKey: "pub_...",
    urlEndpoint: "https://ik.imagekit.io/example",
    privateKey: "pvt_...",
})

const webhookRoute = (req, res) => {
  const signature = req.headers["x-ik-signature"]; // eg. 't=1655788406333,v1=d30758f47fcb31e1fa0109d3b3e2a6c623e699aaf1461cba6bd462ef58ea4b31'
  const rawBody = req.rawBody;// Unmodified request body encoded as Uint8Array or UTF8 string, eg. '{"type":"video.transformation.accepted","id":"58e6d24d-6098-4319-be8d-40c3cb0a402d","created_at":"2022-06-20T11:59:58.461Z","request":{"x_request_id":"fa98fa2e-d6cd-45b4-acf5-bc1d2bbb8ba9","url":"http://ik.imagekit.io/demo/sample-video.mp4?tr=f-webm,q-10","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:101.0) Gecko/20100101 Firefox/101.0"},"data":{"asset":{"url":"http://ik.imagekit.io/demo/sample-video.mp4"},"transformation":{"type":"video-transformation","options":{"video_codec":"vp9","audio_codec":"opus","auto_rotate":true,"quality":10,"format":"webm"}}}}'
  const { timestamp, event } = imagekit.verifyWebhookEvent(rawBody, signature, WEBHOOK_SECRET);
}
```

In typescript

```ts
import Imagekit from "imagekit";

const WEBHOOK_SECRET = "whsec_...";

const imagekit = new Imagekit({
    publicKey: "pub_...",
    urlEndpoint: "https://ik.imagekit.io/example",
    privateKey: "pvt_...",
})

const webhookRoute = (req, res) => {
  const signature = req.headers["x-ik-signature"];
  const rawBody = req.rawBody;
  const { timestamp, event } = imagekit.verifyWebhookEvent(rawBody, signature, WEBHOOK_SECRET);
}
```

> Webhook request body is JSON string of webhook event payload.
> However you can use `event` object returned by `verifyWebhookEvent` method, for webhook event payload.

### Expired webhook | Checking timestamp

`verifyWebhookEvent` only checks if webhook signature is correct for the webhook payload and given timestamp.

Check for expired webhook has to be performed explicitly

```ts
// let signature = 't=1655788406333,v1=d30758f47fcb31e1fa0109d3b3e2a6c623e699aaf1461cba6bd462ef58ea4b31'
const {
  timestamp, // Unix epoch, in milliseconds eg: 1655788406333 as Number
  event
} = imagekit.verifyWebhookEvent(rawBody, signature, WEBHOOK_SECRET);

const WEBHOOK_EXPIRY_DURATION

// Check if webhook is expired
if ( ( Date.now() - timestamp ) > WEBHOOK_EXPIRY_DURATION ) {
   throw Error("Webhook expired")
}
```

### Type Support

```ts
import type {
    WebhookEvent,
    WebhookEventVideoTransformationAccepted,
    WebhookEventVideoTransformationReady,
    WebhookEventVideoTransformationError
} from 'imagekit/dist/libs/interfaces';

const { 
  timestamp,
  event // as WebhookEvent
} = imagekit.verifyWebhookEvent(rawBody, signature, WEBHOOK_SECRET);


// Take advantage of event type

switch (event.type) {
  case "video.transformation.accepted":
    event // as WebhookEventVideoTransformationAccepted
    break;
  case "video.transformation.ready":
    event // as WebhookEventVideoTransformationReady
    break;
  case "video.transformation.error":
    event // as WebhookEventVideoTransformationError
    console.log("Video transformation error");
    break;
}
```

### Upcoming Documentations

https://github.com/imagekitio/docs-keep-a-changelog/pull/49
