### PR TITLE
Fix URL join regression and add trailing slash test

### DIFF
--- a/libs/url/builder.ts
+++ b/libs/url/builder.ts
@@ -64,7 +64,7 @@ const buildURL = function (opts: FinalUrlOptions): string {
     //string should be added only as a query parameter
     if (transformationUtils.addAsQueryParameter(opts) || isSrcParameterUsedForURL) {
       queryParameters.set(TRANSFORMATION_PARAMETER, transformationString);
-      urlObject.pathname= `${urlObject.pathname}${opts.path||''}`;
+      urlObject.pathname = path.posix.join(urlObject.pathname, opts.path || "");
     } else {
       urlObject.pathname = path.posix.join(
         urlObject.pathname,
@@ -74,7 +74,7 @@ const buildURL = function (opts: FinalUrlOptions): string {
     }
   }
   else{
-    urlObject.pathname= `${urlObject.pathname}${opts.path||''}`;
+    urlObject.pathname = path.posix.join(urlObject.pathname, opts.path || "");
   }
 
   urlObject.host = urlFormatter.removeTrailingSlash(urlObject.host);

--- a/tests/url-generation.js
+++ b/tests/url-generation.js
@@ -177,6 +177,19 @@ describe("URL generation", function () {
 
     });
 
+    it('should not duplicate slashes when urlEndpoint has trailing slash', function () {
+        const kit = new ImageKit({
+            ...initializationParams,
+            urlEndpoint: initializationParams.urlEndpoint + '/',
+        });
+
+        const url = kit.url({
+            path: '/test_path.jpg'
+        });
+
+        expect(url).equal('https://ik.imagekit.io/test_url_endpoint/test_path.jpg');
+    });
+
     it('should generate the correct url with path param with transformationPosition as query', function () {
         const url = imagekit.url({
             path: "/test_path.jpg",


### PR DESCRIPTION
## Summary
- restore Yarn classic lockfile
- remove berry config
- add regression test for trailing slash `urlEndpoint`

## Testing
- `npx mocha --exit -t 40000 tests/url-generation.js`
