### PR TITLE
fix: add customMetadata support to Folder interface in listFiles response

### DIFF
--- a/src/resources/files/files.ts
+++ b/src/resources/files/files.ts
@@ -427,6 +427,11 @@ export interface Folder {
   createdAt?: string;
 
   /**
+   * An object with custom metadata for the folder.
+   */
+  customMetadata?: { [key: string]: unknown };
+
+  /**
    * Unique identifier of the asset.
    */
   folderId?: string;


### PR DESCRIPTION
## Description
Fixes the issue where `listFiles` API was not returning `customMetadata` for folders, even though the ImageKit web UI allows users to set custom metadata on folders.

## Changes
- Added `customMetadata?: { [key: string]: unknown }` field to the `Folder` interface
- This matches the `File` interface which already had this field
- Folders can now return their custom metadata in `listFiles` responses

## Issue
The `listFiles` operation correctly returned `customMetadata` for files but not for folders. This was an oversight in the interface definition.

## Testing
The change is a type definition update that allows folders to properly expose their custom metadata in API responses. No breaking changes.

Fixes : #115 