### PR TITLE
docs: fix pnpm link flag typo in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ $ yarn link @imagekit/nodejs
 # With pnpm
 $ pnpm link --global
 $ cd ../my-package
-$ pnpm link -—global @imagekit/nodejs
+$ pnpm link --global @imagekit/nodejs
 ```
 
 ## Running tests


### PR DESCRIPTION
Fixes a typo in the pnpm linking command in CONTRIBUTING.md that caused copy-paste failures.

<img width="746" height="166" alt="Screenshot 2026-02-20 at 9 35 58 PM" src="https://github.com/user-attachments/assets/328aab7d-bcce-479e-b16c-e27610a10825" />

